### PR TITLE
fix(corvus): build macOS binaries natively and sign for Gatekeeper

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -28,16 +28,79 @@ jobs:
         working-directory: cli-ts
         run: bun install --frozen-lockfile
 
-      - name: Build binaries
+      - name: Build Linux binaries
         working-directory: cli-ts
-        run: bash scripts/build.sh
+        run: |
+          mkdir -p dist-bin
+          for target in bun-linux-x64 bun-linux-arm64; do
+            platform="${target#bun-}"
+            outfile="dist-bin/corvus-${platform}"
+            echo "  Building ${platform}..."
+            bun build src/index.ts --compile --target="$target" --outfile="$outfile"
+            echo "  ✓ ${outfile}"
+          done
 
-      - name: Upload artifacts
+      - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: corvus-binaries
-          path: cli-ts/dist-bin/corvus-*
-          retention-days: 30
+          name: corvus-linux
+          path: cli-ts/dist-bin/corvus-linux-*
+          retention-days: 1
+
+  build-macos:
+    runs-on: macos-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        working-directory: cli-ts
+        run: bun install --frozen-lockfile
+
+      - name: Build macOS binaries
+        working-directory: cli-ts
+        run: |
+          mkdir -p dist-bin
+          for target in bun-darwin-arm64 bun-darwin-x64; do
+            platform="${target#bun-}"
+            outfile="dist-bin/corvus-${platform}"
+            echo "  Building ${platform}..."
+            bun build src/index.ts --compile --target="$target" --outfile="$outfile"
+            # Ad-hoc sign so macOS Gatekeeper accepts the binary without a
+            # Developer ID certificate. Quarantine xattr is added by the
+            # downloader (curl/browser), not by CI, so no need to strip it here.
+            codesign --sign - "$outfile"
+            echo "  ✓ ${outfile}"
+          done
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: corvus-macos
+          path: cli-ts/dist-bin/corvus-darwin-*
+          retention-days: 1
+
+  publish:
+    needs: [build-linux, build-macos]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist-bin
+          merge-multiple: true
 
       - name: Publish release
         env:
@@ -46,7 +109,7 @@ jobs:
           gh release delete cli-latest --yes 2>/dev/null || true
           git tag -f cli-latest
           git push -f origin cli-latest
-          gh release create cli-latest cli-ts/dist-bin/corvus-* \
+          gh release create cli-latest dist-bin/corvus-* \
             --title "corvus latest" \
             --notes "Latest build from main" \
             --latest

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,14 @@ TMP=$(mktemp)
 curl -fsSL "$URL" -o "$TMP"
 chmod +x "$TMP"
 
+# macOS Gatekeeper kills unsigned binaries downloaded from the internet.
+# Strip the quarantine attribute and ad-hoc sign so it runs without an
+# Apple Developer account.
+if [ "$(uname -s)" = "Darwin" ]; then
+  xattr -d com.apple.quarantine "$TMP" 2>/dev/null || true
+  codesign --sign - "$TMP" 2>/dev/null || true
+fi
+
 if [ -w "$INSTALL_DIR" ]; then
   mv "$TMP" "${INSTALL_DIR}/corvus"
 elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then


### PR DESCRIPTION
## Summary

Fixes `[1] XXXXX killed corvus` on macOS when installing via curl.

**Root cause.** The CI was cross-compiling macOS binaries on `ubuntu-latest` using `bun build --compile --target=bun-darwin-*`. Bun appends the bundled JS as a blob after the Mach-O binary, and this layout is only valid when the binary is compiled natively on macOS. Cross-compiled binaries produce a format that `codesign` cannot process at all, so the binaries ship unsigned. macOS Gatekeeper sends SIGKILL to any unsigned binary downloaded from the internet, regardless of architecture match.

**Changes.**

- `cli-build.yml`: split into three jobs. `build-linux` runs on `ubuntu-latest` for Linux targets. `build-macos` runs on `macos-latest` for Darwin targets and calls `codesign --sign -` (ad-hoc, no Developer ID required) on each binary before upload. `publish` collects both artifact sets and creates the release.
- `install.sh`: on macOS, strip the `com.apple.quarantine` xattr and ad-hoc sign the downloaded binary before moving it into place. This is a belt-and-suspenders fallback for any already-released unsigned binary and for future installers running on a machine where `codesign` is available.

## Test plan

- [ ] `curl` install on macOS arm64, run `corvus` without getting killed
- [ ] `curl` install on macOS x64, run `corvus` without getting killed
- [ ] Linux install unaffected (xattr/codesign block is Darwin-only)
- [ ] CI produces four binaries (darwin-arm64, darwin-x64, linux-x64, linux-arm64) and publishes release