### PR TITLE
fix(install): ad-hoc sign corvus so curl|bash works on Apple Silicon, add uninstall.sh

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -73,13 +73,11 @@ jobs:
             outfile="dist-bin/corvus-${platform}"
             echo "  Building ${platform}..."
             bun build src/index.ts --compile --target="$target" --outfile="$outfile"
-            # Bun emits a malformed LC_CODE_SIGNATURE stub, so `codesign --sign -`
-            # alone fails with "invalid or unsupported format" and silently
-            # leaves the binary unsigned. Strip first, then ad-hoc sign, then
-            # verify — without verification the build can silently ship an
-            # unsigned arm64 binary that macOS kernel refuses to exec.
-            codesign --remove-signature "$outfile" 2>/dev/null || true
-            codesign --force --sign - "$outfile"
+            # Bun emits a malformed LC_CODE_SIGNATURE stub; sign-macos.sh strips
+            # it and applies an ad-hoc signature. `codesign -dv` verifies the
+            # result so the build can't silently ship an unsigned arm64 binary
+            # that the macOS kernel refuses to exec.
+            ../scripts/sign-macos.sh "$outfile"
             codesign -dv "$outfile"
             echo "  ✓ ${outfile}"
           done

--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -73,10 +73,14 @@ jobs:
             outfile="dist-bin/corvus-${platform}"
             echo "  Building ${platform}..."
             bun build src/index.ts --compile --target="$target" --outfile="$outfile"
-            # Ad-hoc sign so macOS Gatekeeper accepts the binary without a
-            # Developer ID certificate. Quarantine xattr is added by the
-            # downloader (curl/browser), not by CI, so no need to strip it here.
-            codesign --sign - "$outfile"
+            # Bun emits a malformed LC_CODE_SIGNATURE stub, so `codesign --sign -`
+            # alone fails with "invalid or unsupported format" and silently
+            # leaves the binary unsigned. Strip first, then ad-hoc sign, then
+            # verify — without verification the build can silently ship an
+            # unsigned arm64 binary that macOS kernel refuses to exec.
+            codesign --remove-signature "$outfile" 2>/dev/null || true
+            codesign --force --sign - "$outfile"
+            codesign -dv "$outfile"
             echo "  ✓ ${outfile}"
           done
 

--- a/cli-ts/scripts/build.sh
+++ b/cli-ts/scripts/build.sh
@@ -30,8 +30,7 @@ for target in "${TARGETS[@]}"; do
   # Bun emits a malformed LC_CODE_SIGNATURE stub; strip it and ad-hoc sign
   # so Apple Silicon will exec the binary without an Apple Developer cert.
   if [[ "$target" == bun-darwin-* ]] && [[ "$(uname -s)" == "Darwin" ]]; then
-    codesign --remove-signature "$outfile" 2>/dev/null || true
-    codesign --force --sign - "$outfile"
+    "${PROJECT_DIR}/../scripts/sign-macos.sh" "$outfile"
   fi
 
   echo "  ✓ ${outfile}"

--- a/cli-ts/scripts/build.sh
+++ b/cli-ts/scripts/build.sh
@@ -26,6 +26,14 @@ for target in "${TARGETS[@]}"; do
     --compile \
     --target="$target" \
     --outfile="$outfile" 2>/dev/null
+
+  # Bun emits a malformed LC_CODE_SIGNATURE stub; strip it and ad-hoc sign
+  # so Apple Silicon will exec the binary without an Apple Developer cert.
+  if [[ "$target" == bun-darwin-* ]] && [[ "$(uname -s)" == "Darwin" ]]; then
+    codesign --remove-signature "$outfile" 2>/dev/null || true
+    codesign --force --sign - "$outfile"
+  fi
+
   echo "  ✓ ${outfile}"
 done
 

--- a/install.sh
+++ b/install.sh
@@ -21,12 +21,18 @@ TMP=$(mktemp)
 curl -fsSL "$URL" -o "$TMP"
 chmod +x "$TMP"
 
-# macOS Gatekeeper kills unsigned binaries downloaded from the internet.
-# Strip the quarantine attribute and ad-hoc sign so it runs without an
-# Apple Developer account.
+# On Apple Silicon the kernel refuses to exec unsigned arm64 Mach-Os
+# (the user sees a "can't verify developer / Apple ID" dialog). Bun's
+# --compile output ships with a malformed LC_CODE_SIGNATURE stub, so a
+# plain `codesign --sign -` fails with "invalid or unsupported format".
+# Strip the stub first, then ad-hoc sign.
 if [ "$(uname -s)" = "Darwin" ]; then
-  xattr -d com.apple.quarantine "$TMP" 2>/dev/null || true
-  codesign --sign - "$TMP" 2>/dev/null || true
+  xattr -c "$TMP" 2>/dev/null || true
+  codesign --remove-signature "$TMP" 2>/dev/null || true
+  if ! codesign --force --sign - "$TMP" 2>/dev/null; then
+    echo "Warning: ad-hoc codesign failed. If 'corvus' is killed on launch, run:" >&2
+    echo "  codesign --remove-signature \"\$(command -v corvus)\" && codesign --force --sign - \"\$(command -v corvus)\"" >&2
+  fi
 fi
 
 if [ -w "$INSTALL_DIR" ]; then

--- a/install.sh
+++ b/install.sh
@@ -16,22 +16,32 @@ esac
 BINARY="corvus-${OS}-${ARCH}"
 URL="https://github.com/${REPO}/releases/download/${TAG}/${BINARY}"
 
-echo "Downloading ${BINARY}..."
 TMP=$(mktemp)
-curl -fsSL "$URL" -o "$TMP"
+trap 'rm -f "$TMP"' EXIT
+
+if command -v corvus >/dev/null 2>&1; then
+  EXISTING=$(corvus --version 2>/dev/null | head -n1 || echo "unknown")
+  echo "Replacing existing corvus (${EXISTING})..."
+fi
+
+echo "Downloading ${BINARY}..."
+curl -fL --progress-bar "$URL" -o "$TMP"
 chmod +x "$TMP"
 
 # On Apple Silicon the kernel refuses to exec unsigned arm64 Mach-Os
 # (the user sees a "can't verify developer / Apple ID" dialog). Bun's
 # --compile output ships with a malformed LC_CODE_SIGNATURE stub, so a
 # plain `codesign --sign -` fails with "invalid or unsupported format".
-# Strip the stub first, then ad-hoc sign.
+# Strip the stub first, then ad-hoc sign. Keep in sync with
+# scripts/sign-macos.sh (the build-side copy).
 if [ "$(uname -s)" = "Darwin" ]; then
   xattr -c "$TMP" 2>/dev/null || true
   codesign --remove-signature "$TMP" 2>/dev/null || true
   if ! codesign --force --sign - "$TMP" 2>/dev/null; then
-    echo "Warning: ad-hoc codesign failed. If 'corvus' is killed on launch, run:" >&2
-    echo "  codesign --remove-signature \"\$(command -v corvus)\" && codesign --force --sign - \"\$(command -v corvus)\"" >&2
+    echo "Error: ad-hoc codesign failed — refusing to install an unsigned binary." >&2
+    echo "       macOS would kill it on launch. Ensure command-line tools are installed:" >&2
+    echo "         xcode-select --install" >&2
+    exit 1
   fi
 fi
 
@@ -43,7 +53,20 @@ else
   INSTALL_DIR="$HOME/.local/bin"
   mkdir -p "$INSTALL_DIR"
   mv "$TMP" "${INSTALL_DIR}/corvus"
-  echo "  Note: add ~/.local/bin to your PATH if not already present"
+  case ":${PATH:-}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *)
+      shell_name=$(basename "${SHELL:-/bin/sh}")
+      case "$shell_name" in
+        zsh)  path_cmd="echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc" ;;
+        bash) path_cmd="echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc" ;;
+        fish) path_cmd="fish_add_path \$HOME/.local/bin" ;;
+        *)    path_cmd="export PATH=\"\$HOME/.local/bin:\$PATH\"  # add to your shell rc" ;;
+      esac
+      echo "  Note: ~/.local/bin is not on your PATH. Add it with:"
+      echo "    $path_cmd"
+      ;;
+  esac
 fi
 
 echo "✓ Installed to ${INSTALL_DIR}/corvus"

--- a/scripts/sign-macos.sh
+++ b/scripts/sign-macos.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Usage: scripts/sign-macos.sh <path-to-binary>
+#
+# Strips Bun's malformed LC_CODE_SIGNATURE stub and applies an ad-hoc signature
+# so Apple Silicon will exec the binary without a Developer ID cert.
+#
+# NOTE: install.sh inlines an equivalent block (it runs via curl|bash with no
+# repo checkout). Keep the two in sync.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <path-to-binary>" >&2
+  exit 2
+fi
+
+target="$1"
+if [ ! -f "$target" ]; then
+  echo "sign-macos.sh: no such file: $target" >&2
+  exit 1
+fi
+
+xattr -c "$target" 2>/dev/null || true
+codesign --remove-signature "$target" 2>/dev/null || true
+codesign --force --sign - "$target"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -50,8 +50,8 @@ if [ "$PURGE" -eq 1 ] && [ -d "$HOME/.corvus" ]; then
     exit 2
   fi
   echo ""
-  echo "~/.corvus/ contains:"
-  ls -A "$HOME/.corvus" | sed 's/^/  /'
+  echo "$HOME/.corvus/ contains:"
+  find "$HOME/.corvus" -maxdepth 1 -mindepth 1 | while IFS= read -r f; do echo "  $(basename "$f")"; done
   printf "Remove ~/.corvus/ and all installed skills? [y/N] "
   read -r ans || ans=""
   case "$ans" in

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,26 +2,79 @@
 set -euo pipefail
 
 # Removes the corvus binary from the locations install.sh writes to.
-# Does NOT touch skills installed via `corvus install <skill>` — manage those
-# with `corvus uninstall <skill>` before running this if you want them gone.
+#
+# By default, leaves ~/.corvus/ (config and skills installed via
+# `corvus install <skill>`) untouched. Pass --purge to also remove it
+# after a y/N confirm.
+
+PURGE=0
+case "${1:-}" in
+  --purge) PURGE=1 ;;
+  "") ;;
+  *) echo "Usage: $0 [--purge]" >&2; exit 2 ;;
+esac
 
 REMOVED=0
-for path in /usr/local/bin/corvus "$HOME/.local/bin/corvus"; do
-  if [ -e "$path" ] || [ -L "$path" ]; then
-    if [ -w "$(dirname "$path")" ]; then
-      rm -f "$path"
-      echo "✓ Removed $path"
-      REMOVED=$((REMOVED + 1))
-    elif command -v sudo >/dev/null 2>&1; then
-      sudo rm -f "$path"
-      echo "✓ Removed $path"
-      REMOVED=$((REMOVED + 1))
-    else
-      echo "✗ Cannot remove $path (no write permission, no sudo available)" >&2
-    fi
+FAILED=0
+
+remove_path() {
+  local path="$1"
+  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+    return
   fi
+  if [ -w "$(dirname "$path")" ]; then
+    rm -f "$path"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo rm -f "$path"
+  else
+    echo "✗ Cannot remove $path (no write permission, no sudo available)" >&2
+    FAILED=$((FAILED + 1))
+    return
+  fi
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    echo "✗ Failed to remove $path (still present after rm)" >&2
+    FAILED=$((FAILED + 1))
+  else
+    echo "✓ Removed $path"
+    REMOVED=$((REMOVED + 1))
+  fi
+}
+
+for path in /usr/local/bin/corvus "$HOME/.local/bin/corvus"; do
+  remove_path "$path"
 done
 
-if [ "$REMOVED" -eq 0 ]; then
+if [ "$PURGE" -eq 1 ] && [ -d "$HOME/.corvus" ]; then
+  if [ ! -t 0 ]; then
+    echo "✗ --purge requires an interactive terminal for confirmation" >&2
+    exit 2
+  fi
+  echo ""
+  echo "~/.corvus/ contains:"
+  ls -A "$HOME/.corvus" | sed 's/^/  /'
+  printf "Remove ~/.corvus/ and all installed skills? [y/N] "
+  read -r ans || ans=""
+  case "$ans" in
+    y|Y|yes|YES)
+      rm -rf "$HOME/.corvus"
+      if [ -e "$HOME/.corvus" ]; then
+        echo "✗ Failed to remove ~/.corvus/" >&2
+        FAILED=$((FAILED + 1))
+      else
+        echo "✓ Removed ~/.corvus/"
+        REMOVED=$((REMOVED + 1))
+      fi
+      ;;
+    *)
+      echo "Skipped ~/.corvus/"
+      ;;
+  esac
+fi
+
+if [ "$REMOVED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
   echo "corvus not found in /usr/local/bin or ~/.local/bin — nothing to remove"
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Removes the corvus binary from the locations install.sh writes to.
+# Does NOT touch skills installed via `corvus install <skill>` — manage those
+# with `corvus uninstall <skill>` before running this if you want them gone.
+
+REMOVED=0
+for path in /usr/local/bin/corvus "$HOME/.local/bin/corvus"; do
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    if [ -w "$(dirname "$path")" ]; then
+      rm -f "$path"
+      echo "✓ Removed $path"
+      REMOVED=$((REMOVED + 1))
+    elif command -v sudo >/dev/null 2>&1; then
+      sudo rm -f "$path"
+      echo "✓ Removed $path"
+      REMOVED=$((REMOVED + 1))
+    else
+      echo "✗ Cannot remove $path (no write permission, no sudo available)" >&2
+    fi
+  fi
+done
+
+if [ "$REMOVED" -eq 0 ]; then
+  echo "corvus not found in /usr/local/bin or ~/.local/bin — nothing to remove"
+fi


### PR DESCRIPTION
# Hotfix: corvus install broken on Apple Silicon + new uninstall.sh

This PR ships two things:

1. A fix for the `curl | bash` installer, which currently places a binary that is SIGKILL'd on launch on Apple Silicon.
2. A new `uninstall.sh` companion script for symmetric teardown.

A follow-up commit (`3eaa245`) tightens the UX and de-duplicates the signing logic; see the "Follow-up" section below.

---

## 1. Install fix

### Problem

`curl -fsSL .../install.sh | bash` completes successfully, but `corvus --version` exits 137 on arm64 Macs with a "cannot verify developer / Apple ID required" Gatekeeper dialog.

### Root cause

Bun's `bun build --compile` output carries a malformed `LC_CODE_SIGNATURE` stub (load command declares `datasize=140912`, embedded blob header declares `480562`). Any `codesign --sign -` call reads the broken stub first and bails with `invalid or unsupported format for signature`. The arm64 kernel then refuses to exec the unsigned Mach-O.

Three places should have caught this and all three silently swallowed the failure:

- `install.sh` — `codesign --sign - … 2>/dev/null || true`
- `cli-ts/scripts/build.sh` — same pattern
- `.github/workflows/cli-build.yml` — no verification, so the broken binary was published to `cli-latest` as `code object is not signed at all`

### The fix

Two-command sequence, applied in all three places:

```bash
codesign --remove-signature <binary>   # strip Bun's malformed stub
codesign --force --sign - <binary>     # ad-hoc sign (no Apple Developer cert)
```

Ad-hoc signing (identity `-`) is the $0 path used by Homebrew bottles, uv, fnm, etc. It satisfies the kernel's "must have a valid signature" check without a \$99 Developer ID.

### CI regression guard

Added `codesign -dv "$outfile"` after signing in `cli-build.yml`. This is what would have caught today's bug — without it, CI can silently ship an unsigned binary again.

---

## 2. New `uninstall.sh`

Symmetric companion to `install.sh`, for clean teardown and for testing install/reinstall cycles.

### Behavior

- Removes `corvus` from `/usr/local/bin` and `~/.local/bin`
- Falls back to `sudo rm` when the target directory isn't user-writable
- Idempotent — running it twice prints "nothing to remove" on the second run
- Leaves user-installed skills alone (those belong to `corvus uninstall <skill>`)

### Usage

```bash
curl -fsSL https://raw.githubusercontent.com/ravnhq/ai-toolkit/main/uninstall.sh | bash
```

---

## Follow-up: tightening (commit `3eaa245`)

A small round of UX and robustness fixes on top of the hotfix. Scripts grew from 50 + 27 lines to ~80 + ~80; no new dependencies.

### `install.sh`

- `trap 'rm -f "$TMP"' EXIT` — mid-run failures no longer orphan temp files in `/tmp`.
- `curl -fL --progress-bar` (was `-fsSL`) — visible download progress instead of silent pause.
- **Hard-fail on codesign failure** on Darwin. The previous warn-and-continue still installed an unsigned binary the kernel was about to kill. Now it aborts and points at `xcode-select --install`.
- Detects an existing install and logs `Replacing existing corvus (<version>)…` so re-runs aren't silent overwrites.
- `~/.local/bin` fallback now (a) only prints the PATH nag if the dir isn't already on `$PATH`, and (b) tailors the suggestion to the user's `$SHELL` (zsh/bash/fish) — exact copy-pasteable command instead of a vague "add it to your PATH".

### `uninstall.sh`

- **`--purge` flag** — also removes `~/.corvus/` (config + `corvus install <skill>` state) after listing its contents and asking `[y/N]`. Requires a TTY; piped stdin is refused.
- Verifies each `rm` actually removed the target; exits non-zero if anything is still present afterward.
- Rejects unknown args with a usage line and exit 2.

### `scripts/sign-macos.sh` (new)

Extracts the xattr/remove-signature/ad-hoc-sign sequence into a shared helper. `cli-ts/scripts/build.sh` and `.github/workflows/cli-build.yml` now call it instead of inlining. `install.sh` keeps an inline copy (curl|bash has no repo checkout) with a comment flagging it as the mirror — future Bun fixes touch two places instead of three.

---

## Testing

### What's verified

- [x] Bug reproduced against `main` on macOS 26.2 / Apple Silicon: `corvus --version` → exit 137, `codesign -dv` → `code object is not signed at all`.
- [x] Fix verified on this branch: `corvus --version` → `0.1.1` exit 0, `codesign -dv` → `Signature=adhoc`.
- [x] `uninstall.sh` removes the binary and is idempotent.
- [x] All shell scripts pass `bash -n`.
- [x] `sign-macos.sh` rejects missing arg (exit 2) and missing file (exit 1).
- [x] `uninstall.sh --purge` refuses without a TTY; `uninstall.sh --bogus` exits 2 with usage.

### Still to check

- [ ] CI run on this PR: new `codesign -dv` step passes for both darwin slices.
- [ ] Post-merge: the republished `cli-latest` binary is `Signature=adhoc` *directly from the release*, not relying on client-side fixup.
- [ ] End-to-end: `bash install.sh` against the rebuilt release, then `bash uninstall.sh --purge` in an interactive shell.

### Try it without merging

```bash
# wipe any prior install
sudo rm -f /usr/local/bin/corvus; rm -f ~/.local/bin/corvus

# install from this branch
curl -fsSL https://raw.githubusercontent.com/raulpenate/ai-toolkit/hotfix/workaround-for-running-bin-without-apple-dev-account/install.sh | bash
corvus --version
codesign -dv "$(command -v corvus)"

# undo
curl -fsSL https://raw.githubusercontent.com/raulpenate/ai-toolkit/hotfix/workaround-for-running-bin-without-apple-dev-account/uninstall.sh | bash
# or, nuclear:
curl -fsSL .../uninstall.sh | bash -s -- --purge   # note: --purge needs a TTY; run locally
```

---

## Out of scope

- Proper Developer ID signing / notarization (still \$99/yr — what this PR deliberately avoids).
- Upstreaming the Bun signature-stub bug to `oven-sh/bun` (worth a follow-up issue).
- SHA256 checksum verification in `install.sh` (requires publishing checksums from the release workflow — separate PR).