### PR TITLE
Require AskUserQuestion in promptify; fix cli-patterns markdown lint

### DIFF
--- a/.claude-plugin/plugins/design-variations/skills/design-variations/SKILL.md
+++ b/.claude-plugin/plugins/design-variations/skills/design-variations/SKILL.md
@@ -28,7 +28,7 @@ metadata:
   - exploration
   - gallery
   status: ready
-  version: 10
+  version: 11
 ---
 
 # Design Variations

--- a/.claude-plugin/plugins/promptify/skills/promptify/SKILL.md
+++ b/.claude-plugin/plugins/promptify/skills/promptify/SKILL.md
@@ -12,6 +12,7 @@ allowed-tools:
 - Grep
 - Glob
 - Agent
+- AskUserQuestion
 metadata:
   category: assistant
   tags:
@@ -21,7 +22,7 @@ metadata:
   - specification
   - rewriting
   status: ready
-  version: 8
+  version: 9
   triggers:
     positive:
     - 'Promptify this: audit all skills against our findings doc.'
@@ -48,6 +49,8 @@ Rewrite the user's request as a clear, specific, and complete prompt that guides
 
 ## Workflow
 
+> **User-input rule:** Any time this skill needs a decision, preference, or clarification from the user, it MUST use the `AskUserQuestion` tool with structured options — never free-text prose questions. This applies to the clarifying-questions path in step 2 and the delivery choice in step 7.
+
 ### 1. Analyze
 
 Read the user's request carefully. Identify:
@@ -63,7 +66,7 @@ Based on the analysis, choose how to proceed:
 
 - **Request is clear and complete** — produce direct rewritten prompt
 - **1-2 minor gaps** — fill with marked `[Assumption: X]` placeholders and proceed
-- **Major gaps** (audience, scope, tech stack unknown) — ask clarifying questions before rewriting
+- **Major gaps** (audience, scope, tech stack unknown) — ask clarifying questions via the `AskUserQuestion` tool (structured options, not prose) before rewriting
 - **Multiple distinct objectives** — split into separate prompts
 
 ### 3. Structure
@@ -109,7 +112,7 @@ Present the final prompt to the user as a markdown block, clearly labeled. Do no
 
 ### 7. Deliver
 
-After presenting the prompt, offer the user two options:
+After presenting the prompt, use the `AskUserQuestion` tool (not a prose list) to ask the user how to proceed, offering these options:
 
 1. **Execute now** — Treat the generated prompt as your new instruction and proceed based on the current conversation context. Use your normal judgement to decide the best next action — plan complex tasks, implement simple ones directly, or ask clarifying questions if needed.
 2. **Save to file** — Write the prompt to a markdown file in the current working directory (e.g. `promptify-<timestamp>.md` where `<timestamp>` is epoch seconds). Let the user know the file path.

--- a/marketplace.json
+++ b/marketplace.json
@@ -288,7 +288,7 @@
       ],
       "status": "ready",
       "rules": 11,
-      "version": 8
+      "version": 9
     },
     {
       "name": "agent-add-rule",

--- a/skills/assistant/promptify/SKILL.md
+++ b/skills/assistant/promptify/SKILL.md
@@ -12,6 +12,7 @@ allowed-tools:
 - Grep
 - Glob
 - Agent
+- AskUserQuestion
 metadata:
   category: assistant
   tags:
@@ -21,7 +22,7 @@ metadata:
   - specification
   - rewriting
   status: ready
-  version: 8
+  version: 9
   triggers:
     positive:
     - 'Promptify this: audit all skills against our findings doc.'
@@ -48,6 +49,8 @@ Rewrite the user's request as a clear, specific, and complete prompt that guides
 
 ## Workflow
 
+> **User-input rule:** Any time this skill needs a decision, preference, or clarification from the user, it MUST use the `AskUserQuestion` tool with structured options — never free-text prose questions. This applies to the clarifying-questions path in step 2 and the delivery choice in step 7.
+
 ### 1. Analyze
 
 Read the user's request carefully. Identify:
@@ -63,7 +66,7 @@ Based on the analysis, choose how to proceed:
 
 - **Request is clear and complete** — produce direct rewritten prompt
 - **1-2 minor gaps** — fill with marked `[Assumption: X]` placeholders and proceed
-- **Major gaps** (audience, scope, tech stack unknown) — ask clarifying questions before rewriting
+- **Major gaps** (audience, scope, tech stack unknown) — ask clarifying questions via the `AskUserQuestion` tool (structured options, not prose) before rewriting
 - **Multiple distinct objectives** — split into separate prompts
 
 ### 3. Structure
@@ -109,7 +112,7 @@ Present the final prompt to the user as a markdown block, clearly labeled. Do no
 
 ### 7. Deliver
 
-After presenting the prompt, offer the user two options:
+After presenting the prompt, use the `AskUserQuestion` tool (not a prose list) to ask the user how to proceed, offering these options:
 
 1. **Execute now** — Treat the generated prompt as your new instruction and proceed based on the current conversation context. Use your normal judgement to decide the best next action — plan complex tasks, implement simple ones directly, or ask clarifying questions if needed.
 2. **Save to file** — Write the prompt to a markdown file in the current working directory (e.g. `promptify-<timestamp>.md` where `<timestamp>` is epoch seconds). Let the user know the file path.

--- a/skills/cli/platform-cli/references/cli-patterns.md
+++ b/skills/cli/platform-cli/references/cli-patterns.md
@@ -1183,7 +1183,7 @@ curl -L https://example.com/mycli -o /usr/local/bin/mycli
 
 **Correct (uninstall instructions right after install):**
 
-```markdown
+````markdown
 # Installation
 
 ## Homebrew
@@ -1233,7 +1233,7 @@ find ~ -name "*mycli*" 2>/dev/null
 
 # Usage
 ...
-```
+````
 
 **Why it matters:** Users evaluate tools by how easy they are to remove. Hidden or missing uninstall instructions create friction and reduce trust. Placing uninstall steps near install steps makes them discoverable when users need them most.
 


### PR DESCRIPTION
## Summary
- **promptify skill**: Always use the `AskUserQuestion` tool for any user decision/clarification — added it to `allowed-tools`, added a top-of-workflow rule, and updated the clarifying-questions path (step 2) and delivery choice (step 7) to use it instead of prose. Bumped version 8 → 9 in `SKILL.md` and `marketplace.json`.
- **cli-patterns.md**: Fixed an MD001 markdown lint failure caused by nested same-length code fences in the "Correct" uninstall example. The outer block now uses a four-backtick fence so the inner ` ```bash ` blocks render as literal content.
- Includes regenerated `.claude-plugin` artifacts and pending swift/design-variations edits present in the working tree.

## Verification
- `ruby scripts/skills_audit.rb` → PASS (42 skills)
- `ruby scripts/markdown_lint.rb` → exit 0
- `ruby scripts/generate_claude_plugin.rb` → 42 skills regenerated